### PR TITLE
Periodically fetch Connections without lock

### DIFF
--- a/workerpool/pool.go
+++ b/workerpool/pool.go
@@ -49,6 +49,7 @@ func (pool *WorkerPool) Start() {
 				switch event.Type {
 				case watcher.Created:
 					if pool.numWorkers+event.Connection.Source.NumberOfWorkers() > pool.maxWorkers {
+						pool.log.Debugw("creating new job skipped, workers limit exceeded", "connectionID", event.ID)
 						continue
 					}
 

--- a/workerpool/pool.go
+++ b/workerpool/pool.go
@@ -15,24 +15,26 @@ import (
 // WorkerPool is the default struct for our worker pool, containing mostly private values
 // including the maximum workers eligible, current count of workers, etc.
 type WorkerPool struct {
-	maxWorkers uint
-	numWorkers uint
-	session    *concurrency.Session
-	log        *zap.SugaredLogger
-	jobs       map[connection.ID]*job // map of job handlers assigned to each connection.ID
-	events     <-chan *watcher.Event
+	maxWorkers  uint
+	numWorkers  uint
+	locksPrefix string
+	session     *concurrency.Session
+	log         *zap.SugaredLogger
+	jobs        map[connection.ID]*job // map of job handlers assigned to each connection.ID
+	events      <-chan *watcher.Event
 }
 
 // New will accept a few initializer variables in order to stand up the new worker
 // pool of goroutines. These workers will listen for *watcher.Events and handle the
 // internal *Connection to manage data.
-func New(session *concurrency.Session, maxWorkers uint, events <-chan *watcher.Event, log *zap.SugaredLogger) *WorkerPool {
+func New(session *concurrency.Session, maxWorkers uint, events <-chan *watcher.Event, locksPrefix string, log *zap.SugaredLogger) *WorkerPool {
 	return &WorkerPool{
-		maxWorkers: maxWorkers,
-		session:    session,
-		log:        log,
-		jobs:       make(map[connection.ID]*job),
-		events:     events,
+		maxWorkers:  maxWorkers,
+		locksPrefix: locksPrefix,
+		session:     session,
+		log:         log,
+		jobs:        make(map[connection.ID]*job),
+		events:      events,
 	}
 }
 
@@ -46,7 +48,11 @@ func (pool *WorkerPool) Start() {
 
 				switch event.Type {
 				case watcher.Created:
-					job, err := newJob(pool.session, event.Connection, pool.log.Named("job"))
+					if pool.numWorkers+event.Connection.Source.NumberOfWorkers() > pool.maxWorkers {
+						continue
+					}
+
+					job, err := newJob(pool.session, event.Connection, pool.locksPrefix, pool.log.Named("job"))
 					if err != nil {
 						pool.log.Debugw("creating new job failed", "error", err, "connectionID", event.ID)
 						continue
@@ -77,8 +83,6 @@ func (pool *WorkerPool) Stop() {
 	pool.log.Debugf("all jobs stopped")
 }
 
-const lockPrefix = "serverless-event-gateway-connector/locks/connections/"
-
 // job is the interim struct to manage workers for a give connection.
 type job struct {
 	connection *connection.Connection
@@ -89,8 +93,8 @@ type job struct {
 }
 
 // newJob creates new job an tries to lock the connection in etcd.
-func newJob(session *concurrency.Session, conn *connection.Connection, log *zap.SugaredLogger) (*job, error) {
-	mutex := concurrency.NewMutex(session, lockPrefix+string(conn.ID))
+func newJob(session *concurrency.Session, conn *connection.Connection, locksPrefix string, log *zap.SugaredLogger) (*job, error) {
+	mutex := concurrency.NewMutex(session, locksPrefix+string(conn.ID))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
@@ -161,7 +165,7 @@ func (w *worker) run() {
 		default:
 			// perform the actual connection here
 			w.log.Debugw("would be handling the stuff here", "workerID", w.id, "connectionID", w.connection.ID)
-			time.Sleep(3 * time.Second)
+			time.Sleep(1 * time.Second)
 		}
 	}
 }


### PR DESCRIPTION
Previously, Watcher before listening on changes in etcd fetched all values (Connections) and treat them as the initial set of events. So, when the first connector instance started running the existing Connections will be handled.

This PR changes this behavior a bit:
1. function returning existing connections will return only those without lock
2. this function runs periodically, every few seconds so if another instance fails, the connections handled by that instance will be picked up by another instance.

In the next PR, I will add support for updating a Connection (Config API and support in Watcher).
