### PR TITLE
provide checkpoint capabilities for worker goroutines

### DIFF
--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -57,14 +57,11 @@ func main() {
 	}
 	defer client.Close()
 
-	workerKVClient := namespace.NewKV(client, checkpointPrefix)
-
 	// Watcher
 	watch := kv.NewWatcher(
 		namespace.NewKV(client, connectionsPrefix),
 		namespace.NewWatcher(client, connectionsPrefix),
 		namespace.NewKV(client, locksPrefix),
-		workerKVClient,
 		logger.Named("KV.Watcher"),
 	)
 	events, err := watch.Watch()
@@ -81,7 +78,7 @@ func main() {
 	wp := workerpool.New(&workerpool.Config{
 		MaxWorkers:   *maxWorkers,
 		LocksPrefix:  locksPrefix,
-		CheckpointKV: workerKVClient,
+		CheckpointKV: namespace.NewKV(client, checkpointPrefix),
 		Session:      session,
 		Events:       events,
 		Log:          logger.Named("WorkerPool"),

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -23,8 +24,6 @@ import (
 	_ "github.com/serverless/event-gateway-connector/sources/awscloudtrail"
 	_ "github.com/serverless/event-gateway-connector/sources/awskinesis"
 )
-
-const prefix = "serverless-event-gateway-connector/"
 
 const jobsBucketSize = 5
 
@@ -63,7 +62,7 @@ func main() {
 	defer watch.Stop()
 
 	// KV store service
-	store := kv.NewStore(namespace.NewKV(client, prefix), jobsBucketSize, logger.Named("KV.Store"))
+	store := kv.NewStore(namespace.NewKV(client, kv.GetPrefix()), jobsBucketSize, logger.Named("KV.Store"))
 
 	// Initalize the WorkerPool
 	session, err := concurrency.NewSession(client)
@@ -72,7 +71,7 @@ func main() {
 	}
 	wp := workerpool.New(&workerpool.Config{
 		MaxWorkers:   *maxWorkers,
-		LocksPrefix:  kv.GetLocksPrefix(),
+		LocksPrefix:  fmt.Sprintf("%s%s", kv.GetPrefix(), kv.GetLocksPrefix()),
 		CheckpointKV: store,
 		Session:      session,
 		Events:       events,

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -62,7 +62,7 @@ func main() {
 	defer watch.Stop()
 
 	// KV store service
-	store := kv.NewStore(namespace.NewKV(client, kv.GetPrefix()), jobsBucketSize, logger.Named("KV.Store"))
+	store := kv.NewStore(namespace.NewKV(client, kv.PREFIX), jobsBucketSize, logger.Named("KV.Store"))
 
 	// Initalize the WorkerPool
 	session, err := concurrency.NewSession(client)
@@ -71,7 +71,7 @@ func main() {
 	}
 	wp := workerpool.New(&workerpool.Config{
 		MaxWorkers:   *maxWorkers,
-		LocksPrefix:  fmt.Sprintf("%s%s", kv.GetPrefix(), kv.GetLocksPrefix()),
+		LocksPrefix:  fmt.Sprintf("%s%s", kv.PREFIX, kv.LOCKSPREFIX),
 		CheckpointKV: store,
 		Session:      session,
 		Events:       events,

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -12,7 +12,6 @@ import (
 
 	etcd "github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
-	"github.com/coreos/etcd/clientv3/namespace"
 	"github.com/serverless/event-gateway-connector/httpapi"
 	"github.com/serverless/event-gateway-connector/kv"
 	"github.com/serverless/event-gateway-connector/workerpool"
@@ -62,7 +61,7 @@ func main() {
 	defer watch.Stop()
 
 	// KV store service
-	store := kv.NewStore(namespace.NewKV(client, kv.PREFIX), jobsBucketSize, logger.Named("KV.Store"))
+	store := kv.NewStore(client, jobsBucketSize, logger.Named("KV.Store"))
 
 	// Initalize the WorkerPool
 	session, err := concurrency.NewSession(client)
@@ -71,7 +70,7 @@ func main() {
 	}
 	wp := workerpool.New(&workerpool.Config{
 		MaxWorkers:   *maxWorkers,
-		LocksPrefix:  fmt.Sprintf("%s%s", kv.PREFIX, kv.LOCKSPREFIX),
+		LocksPrefix:  fmt.Sprintf("%s%s", kv.Prefix, kv.LocksPrefix),
 		CheckpointKV: store,
 		Session:      session,
 		Events:       events,

--- a/kv/store.go
+++ b/kv/store.go
@@ -15,6 +15,7 @@ import (
 )
 
 const jobsDir = "jobs/"
+const workersDir = "workers/"
 
 // Store implements connection.Service using etcd KV as a backend.
 type Store struct {
@@ -137,6 +138,9 @@ func (store Store) DeleteConnection(space string, id connection.ID) error {
 	deleteConnection := etcd.OpDelete(string(id))
 	deleteJobs := etcd.OpDelete(fmt.Sprintf("%s/%s", id, jobsDir), etcd.WithPrefix())
 	resp, err := store.client.Txn(context.TODO()).Then(deleteConnection, deleteJobs).Commit()
+	// TODO: how do we delete the following prefix? "serverless-event-gateway-connector/workers/<conn.ID>"
+	//	deleteWorkers := etcd.OpDelete(fmt.Sprintf("%s%s", workersDir, id), etcd.WithPrefix())
+	//	resp, err := store.client.Txn(context.TODO()).Then(deleteConnection, deleteJobs, deleteWorkers).Commit()
 	if resp.Responses[0].GetResponseDeleteRange().Deleted == 0 {
 		return ErrKeyNotFound
 	}

--- a/kv/store.go
+++ b/kv/store.go
@@ -15,7 +15,6 @@ import (
 )
 
 const jobsDir = "jobs/"
-const workersDir = "workers/"
 
 // Store implements connection.Service using etcd KV as a backend.
 type Store struct {

--- a/kv/store.go
+++ b/kv/store.go
@@ -36,7 +36,6 @@ func NewStore(client etcd.KV, jobsBucketSize uint, log *zap.SugaredLogger) *Stor
 
 // CreateCheckpoint initalizes a new checkpoint for a specific workerID
 func (store Store) CreateCheckpoint(key string) error {
-	fmt.Printf("DEBUG -- create key is: START%sEND\n", key)
 	_, err := store.client.Txn(context.TODO()).Then(etcd.OpPut(key+"/", "")).Commit()
 	return err
 }
@@ -50,14 +49,12 @@ func (store Store) RetrieveCheckpoint(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("DEBUG -- retrieve key is: START%sEND\n", checkpoint.Kvs[0].Value)
 
 	return string(checkpoint.Kvs[0].Value), nil
 }
 
 // UpdateCheckpoint updates the current checkpoint information for a given workerID
 func (store Store) UpdateCheckpoint(key, value string) error {
-	fmt.Printf("DEBUG -- update key is: START%sEND, value: START%sEND\n", key, value)
 	_, err := store.client.Txn(context.TODO()).Then(etcd.OpPut(key+"/", value)).Commit()
 	return err
 }

--- a/kv/store.go
+++ b/kv/store.go
@@ -56,12 +56,11 @@ func (store Store) UpdateCheckpoint(key, value string) error {
 	return err
 }
 
-//
-//// DeleteCheckpoint removes the checkpoint altogether from the store (usually after removing a connection)
-//func (store Store) DeleteCheckpoint(key string) error {
-//	_, err := store.client.Delete(context.TODO(), key+"/")
-//	return err
-//}
+// DeleteCheckpoint removes the checkpoint altogether from the store (usually after removing a connection)
+func (store Store) DeleteCheckpoint(key string) error {
+	_, err := store.client.Delete(context.TODO(), key+"/")
+	return err
+}
 
 // CreateConnection creates connection in etcd.
 func (store Store) CreateConnection(conn *connection.Connection) (*connection.Connection, error) {

--- a/kv/store.go
+++ b/kv/store.go
@@ -15,6 +15,7 @@ import (
 )
 
 const jobsDir = "jobs/"
+const workerDir = "workers"
 
 // Store implements connection.Service using etcd KV as a backend.
 type Store struct {
@@ -30,12 +31,6 @@ func NewStore(client etcd.KV, jobsBucketSize uint, log *zap.SugaredLogger) *Stor
 		jobsBucketSize: jobsBucketSize,
 		log:            log,
 	}
-}
-
-// CreateCheckpoint initalizes a new checkpoint for a specific workerID
-func (store Store) CreateCheckpoint(key string) error {
-	_, err := store.client.Txn(context.TODO()).Then(etcd.OpPut(key+"/", "")).Commit()
-	return err
 }
 
 // RetrieveCheckpoint returns the existing checkpoint for a given workerID, or an error if not found
@@ -54,12 +49,6 @@ func (store Store) RetrieveCheckpoint(key string) (string, error) {
 // UpdateCheckpoint updates the current checkpoint information for a given workerID
 func (store Store) UpdateCheckpoint(key, value string) error {
 	_, err := store.client.Put(context.TODO(), key+"/", value)
-	return err
-}
-
-// DeleteCheckpoint removes the checkpoint altogether from the store when a job/worker is removed completely
-func (store Store) DeleteCheckpoint(key string) error {
-	_, err := store.client.Delete(context.TODO(), key+"/")
 	return err
 }
 
@@ -142,7 +131,10 @@ func (store Store) UpdateConnection(conn *connection.Connection) (*connection.Co
 func (store Store) DeleteConnection(space string, id connection.ID) error {
 	deleteConnection := etcd.OpDelete(string(id))
 	deleteJobs := etcd.OpDelete(fmt.Sprintf("%s/%s", id, jobsDir), etcd.WithPrefix())
-	resp, err := store.client.Txn(context.TODO()).Then(deleteConnection, deleteJobs).Commit()
+	deleteWorkers := etcd.OpDelete(fmt.Sprintf("%s/%s", workerDir, id), etcd.WithPrefix())
+
+	fmt.Printf("DEBUG -- delConn: %s, delJob: %s, delWork: %s\n", deleteConnection.KeyBytes(), deleteJobs.KeyBytes(), deleteWorkers.KeyBytes())
+	resp, err := store.client.Txn(context.TODO()).Then(deleteConnection, deleteJobs, deleteWorkers).Commit()
 	if resp.Responses[0].GetResponseDeleteRange().Deleted == 0 {
 		return ErrKeyNotFound
 	}

--- a/kv/store.go
+++ b/kv/store.go
@@ -15,7 +15,8 @@ import (
 )
 
 const jobsDir = "jobs/"
-const workersDir = "workers/"
+
+//const workersDir = "workers/"
 
 // Store implements connection.Service using etcd KV as a backend.
 type Store struct {
@@ -35,6 +36,7 @@ func NewStore(client etcd.KV, jobsBucketSize uint, log *zap.SugaredLogger) *Stor
 
 // CreateCheckpoint initalizes a new checkpoint for a specific workerID
 func (store Store) CreateCheckpoint(key string) error {
+	fmt.Printf("DEBUG -- create key is: START%sEND\n", key)
 	_, err := store.client.Txn(context.TODO()).Then(etcd.OpPut(key+"/", "")).Commit()
 	return err
 }
@@ -48,12 +50,14 @@ func (store Store) RetrieveCheckpoint(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	fmt.Printf("DEBUG -- retrieve key is: START%sEND\n", checkpoint.Kvs[0].Value)
 
 	return string(checkpoint.Kvs[0].Value), nil
 }
 
 // UpdateCheckpoint updates the current checkpoint information for a given workerID
 func (store Store) UpdateCheckpoint(key, value string) error {
+	fmt.Printf("DEBUG -- update key is: START%sEND, value: START%sEND\n", key, value)
 	_, err := store.client.Txn(context.TODO()).Then(etcd.OpPut(key+"/", value)).Commit()
 	return err
 }

--- a/kv/store.go
+++ b/kv/store.go
@@ -39,7 +39,7 @@ func NewStore(client etcd.KV, jobsBucketSize uint, log *zap.SugaredLogger) *Stor
 
 // RetrieveCheckpoint returns the existing checkpoint for a given workerID, or an error if not found
 func (store Store) RetrieveCheckpoint(key string) (string, error) {
-	checkpoint, err := store.client.Get(context.TODO(), key+"/", etcd.WithPrefix())
+	checkpoint, err := store.client.Get(context.TODO(), key+"/")
 	if checkpoint.Count == 0 {
 		return "", ErrKeyNotFound
 	}
@@ -56,11 +56,12 @@ func (store Store) UpdateCheckpoint(key, value string) error {
 	return err
 }
 
-// DeleteCheckpoint removes the checkpoint altogether from the store (usually after removing a connection)
-func (store Store) DeleteCheckpoint(key string) error {
-	_, err := store.client.Delete(context.TODO(), key+"/")
-	return err
-}
+//
+//// DeleteCheckpoint removes the checkpoint altogether from the store (usually after removing a connection)
+//func (store Store) DeleteCheckpoint(key string) error {
+//	_, err := store.client.Delete(context.TODO(), key+"/")
+//	return err
+//}
 
 // CreateConnection creates connection in etcd.
 func (store Store) CreateConnection(conn *connection.Connection) (*connection.Connection, error) {

--- a/kv/store.go
+++ b/kv/store.go
@@ -54,7 +54,7 @@ func (store Store) RetrieveCheckpoint(key string) (string, error) {
 
 // UpdateCheckpoint updates the current checkpoint information for a given workerID
 func (store Store) UpdateCheckpoint(key, value string) error {
-	_, err := store.client.Txn(context.TODO()).Then(etcd.OpPut(key, value)).Commit()
+	_, err := store.client.Txn(context.TODO()).Then(etcd.OpPut(key+"/", value)).Commit()
 	return err
 }
 

--- a/kv/store.go
+++ b/kv/store.go
@@ -55,7 +55,7 @@ func (store Store) RetrieveCheckpoint(key string) (string, error) {
 
 // UpdateCheckpoint updates the current checkpoint information for a given workerID
 func (store Store) UpdateCheckpoint(key, value string) error {
-	_, err := store.client.Txn(context.TODO()).Then(etcd.OpPut(key+"/", value)).Commit()
+	_, err := store.client.Put(context.TODO(), key+"/", value)
 	return err
 }
 

--- a/kv/watcher.go
+++ b/kv/watcher.go
@@ -19,7 +19,6 @@ type Watcher struct {
 	connectionsKVClient etcd.KV
 	jobsWatchClient     etcd.Watcher
 	locksKVClient       etcd.KV
-	checkpointKVClient  etcd.KV
 	stopCh              chan struct{}
 	log                 *zap.SugaredLogger
 }

--- a/kv/watcher.go
+++ b/kv/watcher.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -28,10 +29,10 @@ type Watcher struct {
 // NewWatcher creates a new Watcher instance.
 func NewWatcher(client *etcd.Client, log *zap.SugaredLogger) *Watcher {
 	return &Watcher{
-		connectionsKVClient: namespace.NewKV(client, connectionsPrefix),
-		jobsWatchClient:     namespace.NewWatcher(client, connectionsPrefix),
-		locksKVClient:       namespace.NewKV(client, locksPrefix),
-		checkpointKVClient:  namespace.NewKV(client, checkpointPrefix),
+		connectionsKVClient: namespace.NewKV(client, fmt.Sprintf("%s%s", prefix, connectionsPrefix)),
+		jobsWatchClient:     namespace.NewWatcher(client, fmt.Sprintf("%s%s", prefix, connectionsPrefix)),
+		locksKVClient:       namespace.NewKV(client, fmt.Sprintf("%s%s", prefix, locksPrefix)),
+		checkpointKVClient:  namespace.NewKV(client, fmt.Sprintf("%s%s", prefix, checkpointPrefix)),
 		stopCh:              make(chan struct{}),
 		log:                 log,
 	}

--- a/kv/watcher.go
+++ b/kv/watcher.go
@@ -29,10 +29,10 @@ type Watcher struct {
 // NewWatcher creates a new Watcher instance.
 func NewWatcher(client *etcd.Client, log *zap.SugaredLogger) *Watcher {
 	return &Watcher{
-		connectionsKVClient: namespace.NewKV(client, fmt.Sprintf("%s%s", PREFIX, CONNECTIONSPREFIX)),
-		jobsWatchClient:     namespace.NewWatcher(client, fmt.Sprintf("%s%s", PREFIX, CONNECTIONSPREFIX)),
-		locksKVClient:       namespace.NewKV(client, fmt.Sprintf("%s%s", PREFIX, LOCKSPREFIX)),
-		checkpointKVClient:  namespace.NewKV(client, fmt.Sprintf("%s%s", PREFIX, CHECKPOINTPREFIX)),
+		connectionsKVClient: namespace.NewKV(client, fmt.Sprintf("%s%s", Prefix, ConnectionsPrefix)),
+		jobsWatchClient:     namespace.NewWatcher(client, fmt.Sprintf("%s%s", Prefix, ConnectionsPrefix)),
+		locksKVClient:       namespace.NewKV(client, fmt.Sprintf("%s%s", Prefix, LocksPrefix)),
+		checkpointKVClient:  namespace.NewKV(client, fmt.Sprintf("%s%s", Prefix, CheckpointPrefix)),
 		stopCh:              make(chan struct{}),
 		log:                 log,
 	}

--- a/kv/watcher.go
+++ b/kv/watcher.go
@@ -19,6 +19,7 @@ type Watcher struct {
 	connectionsKVClient etcd.KV
 	jobsWatchClient     etcd.Watcher
 	locksKVClient       etcd.KV
+	checkpointKVClient  etcd.KV
 	stopCh              chan struct{}
 	log                 *zap.SugaredLogger
 }

--- a/kv/watcher.go
+++ b/kv/watcher.go
@@ -29,10 +29,10 @@ type Watcher struct {
 // NewWatcher creates a new Watcher instance.
 func NewWatcher(client *etcd.Client, log *zap.SugaredLogger) *Watcher {
 	return &Watcher{
-		connectionsKVClient: namespace.NewKV(client, fmt.Sprintf("%s%s", prefix, connectionsPrefix)),
-		jobsWatchClient:     namespace.NewWatcher(client, fmt.Sprintf("%s%s", prefix, connectionsPrefix)),
-		locksKVClient:       namespace.NewKV(client, fmt.Sprintf("%s%s", prefix, locksPrefix)),
-		checkpointKVClient:  namespace.NewKV(client, fmt.Sprintf("%s%s", prefix, checkpointPrefix)),
+		connectionsKVClient: namespace.NewKV(client, fmt.Sprintf("%s%s", PREFIX, CONNECTIONSPREFIX)),
+		jobsWatchClient:     namespace.NewWatcher(client, fmt.Sprintf("%s%s", PREFIX, CONNECTIONSPREFIX)),
+		locksKVClient:       namespace.NewKV(client, fmt.Sprintf("%s%s", PREFIX, LOCKSPREFIX)),
+		checkpointKVClient:  namespace.NewKV(client, fmt.Sprintf("%s%s", PREFIX, CHECKPOINTPREFIX)),
 		stopCh:              make(chan struct{}),
 		log:                 log,
 	}

--- a/kv/watcher.go
+++ b/kv/watcher.go
@@ -19,16 +19,18 @@ type Watcher struct {
 	connectionsKVClient etcd.KV
 	jobsWatchClient     etcd.Watcher
 	locksKVClient       etcd.KV
+	workerKVClient      etcd.KV
 	stopCh              chan struct{}
 	log                 *zap.SugaredLogger
 }
 
 // NewWatcher creates a new Watcher instance.
-func NewWatcher(connectionsKVClient etcd.KV, jobsWatcher etcd.Watcher, locksKVClient etcd.KV, log *zap.SugaredLogger) *Watcher {
+func NewWatcher(connectionsKVClient etcd.KV, jobsWatcher etcd.Watcher, locksKVClient etcd.KV, workerKVClient etcd.KV, log *zap.SugaredLogger) *Watcher {
 	return &Watcher{
 		connectionsKVClient: connectionsKVClient,
 		jobsWatchClient:     jobsWatcher,
 		locksKVClient:       locksKVClient,
+		workerKVClient:      workerKVClient,
 		stopCh:              make(chan struct{}),
 		log:                 log,
 	}

--- a/sources/awskinesis/awskinesis.go
+++ b/sources/awskinesis/awskinesis.go
@@ -98,12 +98,18 @@ func (a AWSKinesis) Fetch(shardID uint, lastSeq string) (*connection.Records, er
 	if err != nil {
 		return nil, err
 	}
+	if shardID == 0 {
+		fmt.Printf("DEBUG -- params: %+v, iter: %+v\n", params, iter)
+	}
 
 	records, err := a.service.GetRecords(&kinesis.GetRecordsInput{
 		ShardIterator: iter.ShardIterator,
 	})
 	if err != nil {
 		return nil, err
+	}
+	if shardID == 0 {
+		fmt.Printf("DEBUG -- records: %+v\n", records)
 	}
 
 	for _, rec := range records.Records {

--- a/sources/awskinesis/awskinesis.go
+++ b/sources/awskinesis/awskinesis.go
@@ -3,6 +3,7 @@ package awskinesis
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -69,7 +70,10 @@ func Load(data []byte) (connection.Source, error) {
 	if err != nil {
 		return src, err
 	}
-	src.shards = stream.StreamDescription.Shards // TODO we need to sort this slice here, otherwise different instances can have different shard on the same position
+	sort.Slice(stream.StreamDescription.Shards, func(i, j int) bool {
+		return *stream.StreamDescription.Shards[i].ShardId < *stream.StreamDescription.Shards[j].ShardId
+	})
+	src.shards = stream.StreamDescription.Shards
 
 	return src, nil
 }

--- a/sources/awskinesis/awskinesis.go
+++ b/sources/awskinesis/awskinesis.go
@@ -98,18 +98,12 @@ func (a AWSKinesis) Fetch(shardID uint, lastSeq string) (*connection.Records, er
 	if err != nil {
 		return nil, err
 	}
-	if shardID == 0 {
-		fmt.Printf("DEBUG -- params: %+v, iter: %+v\n", params, iter)
-	}
 
 	records, err := a.service.GetRecords(&kinesis.GetRecordsInput{
 		ShardIterator: iter.ShardIterator,
 	})
 	if err != nil {
 		return nil, err
-	}
-	if shardID == 0 {
-		fmt.Printf("DEBUG -- records: %+v\n", records)
 	}
 
 	for _, rec := range records.Records {

--- a/workerpool/checkpoint.go
+++ b/workerpool/checkpoint.go
@@ -6,5 +6,4 @@ package workerpool
 type Checkpointer interface {
 	RetrieveCheckpoint(k string) (string, error)
 	UpdateCheckpoint(k, v string) error
-	DeleteCheckpoint(k string) error
 }

--- a/workerpool/checkpoint.go
+++ b/workerpool/checkpoint.go
@@ -1,0 +1,10 @@
+package workerpool
+
+// Checkpoint is an interface definitoin for a checkpoint-based system for workers
+//   This tool is useful for storing off last-read sequence numbers (aka checkpoints) for
+//   individual sources
+type Checkpoint interface {
+	RetrieveCheckpoint(k string) (string, error)
+	UpdateCheckpoint(k, v string) error
+	DeleteCheckpoint(k string) error
+}

--- a/workerpool/checkpoint.go
+++ b/workerpool/checkpoint.go
@@ -1,6 +1,6 @@
 package workerpool
 
-// Checkpointer is an interface definitoin for a checkpoint-based system for workers
+// Checkpointer is an interface definition for a checkpoint-based system for workers
 //   This tool is useful for storing off last-read sequence numbers (aka checkpoints) for
 //   individual sources
 type Checkpointer interface {

--- a/workerpool/checkpoint.go
+++ b/workerpool/checkpoint.go
@@ -1,9 +1,9 @@
 package workerpool
 
-// Checkpoint is an interface definitoin for a checkpoint-based system for workers
+// Checkpointer is an interface definitoin for a checkpoint-based system for workers
 //   This tool is useful for storing off last-read sequence numbers (aka checkpoints) for
 //   individual sources
-type Checkpoint interface {
+type Checkpointer interface {
 	RetrieveCheckpoint(k string) (string, error)
 	UpdateCheckpoint(k, v string) error
 	DeleteCheckpoint(k string) error

--- a/workerpool/pool.go
+++ b/workerpool/pool.go
@@ -88,9 +88,6 @@ func (pool *WorkerPool) Start() {
 						job.stop()
 						delete(pool.jobs, event.JobID)
 						pool.numWorkers -= job.numWorkers
-						//						if err := pool.checkpointKV.DeleteCheckpoint(string(job.id)); err != nil {
-						//							pool.log.Debugw("could not remove worker checkpoint", "jobID", job.id, "error", err.Error())
-						//						}
 					}
 				}
 			}

--- a/workerpool/pool.go
+++ b/workerpool/pool.go
@@ -228,14 +228,12 @@ func (w *worker) run() {
 					return
 				}
 			}
-			fmt.Printf("%d: checkpointID: %s, checkpoint: %s, lastSeq is: %s\n", w.id, w.checkpointID, checkpoint, data.LastSequence)
-			data, err = w.connection.Source.Fetch(w.id, data.LastSequence)
+			data, err = w.connection.Source.Fetch(w.id, checkpoint)
 			if err != nil {
 				w.log.Errorw("worker failed", "workerID", w.id, "error", err.Error())
 				return
 			}
 			if len(data.Data) == 0 {
-				w.log.Debugw("no data", "workerID", w.id, "data", data)
 				continue
 			}
 
@@ -253,7 +251,6 @@ func (w *worker) run() {
 				w.log.Errorw("worker checkpoint update failed", "workerID", w.id, "checkpointID", w.checkpointID, "checkpoint", data.LastSequence, "error", err.Error())
 				return
 			}
-			fmt.Printf("updated checkpoint with %s\n", data.LastSequence)
 		}
 	}
 }


### PR DESCRIPTION
Leverage `etcd` to store the checkpoint for each worker goroutine. In this case, the checkpoint is the last read record from the source and stored by each `jobID + workerID` in `etcd`.