### PR TITLE
Timeout Fetch call

### DIFF
--- a/sources/amqp/amqp.go
+++ b/sources/amqp/amqp.go
@@ -3,7 +3,6 @@ package amqp
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/streadway/amqp"
 
@@ -64,14 +63,10 @@ func (a *AMQP) Fetch(shardID uint, lastSeq string) (*connection.Records, error) 
 		a.deliveryCh = ch
 	}
 
-	select {
-	case delivery := <-a.deliveryCh:
-		defer delivery.Ack(false)
-		return &connection.Records{Data: [][]byte{delivery.Body}}, nil
-	case <-time.After(1 * time.Second):
-	}
+	delivery := <-a.deliveryCh
+	defer delivery.Ack(false)
 
-	return &connection.Records{Data: [][]byte{}}, nil
+	return &connection.Records{Data: [][]byte{delivery.Body}}, nil
 }
 
 // NumberOfWorkers returns number of shards to handle by the pool

--- a/workerpool/pool.go
+++ b/workerpool/pool.go
@@ -206,6 +206,9 @@ func (w *worker) run() {
 				w.log.Errorw("closing source failed", "workerID", w.id, "error", err.Error())
 			}
 			return
+		case <-time.After(1 * time.Second):
+			// This case is needed to unblock Fetch call below. Otherwise, it can block indefinitely
+			// if the source is using blocking call to the source message queue.
 		default:
 			data, err = w.connection.Source.Fetch(w.id, data.LastSequence)
 			if err != nil {


### PR DESCRIPTION
Another minor fix. This mechanism has to be moved to the WorkerPool as implementing source should be as straight-forward as it's possible.