### PR TITLE
Add support for timeout in Fetch with context object

### DIFF
--- a/connection/source.go
+++ b/connection/source.go
@@ -1,9 +1,11 @@
 package connection
 
+import "context"
+
 // Source is the default interface that each connection source (e.g. awskinesis, kafka) need
 // to satisfy in order to deliver events to the EG.
 type Source interface {
-	Fetch(uint, string) (*Records, error)
+	Fetch(context.Context, uint, string) (*Records, error)
 	NumberOfWorkers() uint
 	Close() error
 }

--- a/sources/awscloudtrail/awscloudtrail.go
+++ b/sources/awscloudtrail/awscloudtrail.go
@@ -1,6 +1,7 @@
 package awscloudtrail
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -67,7 +68,7 @@ func (a AWSCloudTrail) validate() error {
 }
 
 // Fetch retrieves the next event from the awscloudtrail source
-func (a AWSCloudTrail) Fetch(shardID uint, lastSeq string) (*connection.Records, error) {
+func (a AWSCloudTrail) Fetch(ctx context.Context, shardID uint, lastSeq string) (*connection.Records, error) {
 	var start time.Time
 	ret := &connection.Records{}
 	maxResults := int64(50)
@@ -87,7 +88,7 @@ func (a AWSCloudTrail) Fetch(shardID uint, lastSeq string) (*connection.Records,
 		params.StartTime = &start
 	}
 
-	resp, err := a.Service.LookupEvents(params)
+	resp, err := a.Service.LookupEventsWithContext(ctx, params)
 	if err != nil {
 		return nil, err
 	}

--- a/sources/awskinesis/awskinesis.go
+++ b/sources/awskinesis/awskinesis.go
@@ -1,6 +1,7 @@
 package awskinesis
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -80,7 +81,7 @@ func Load(data []byte) (connection.Source, error) {
 
 // Fetch retrieves the next document from the awskinesis source
 // Borrrowed some items from https://github.com/harlow/kinesis-consumer/blob/master/consumer.go#L251
-func (a AWSKinesis) Fetch(shardID uint, lastSeq string) (*connection.Records, error) {
+func (a AWSKinesis) Fetch(ctx context.Context, shardID uint, lastSeq string) (*connection.Records, error) {
 	ret := &connection.Records{LastSequence: lastSeq}
 	params := &kinesis.GetShardIteratorInput{
 		ShardId:           a.shards[shardID].ShardId,
@@ -94,12 +95,12 @@ func (a AWSKinesis) Fetch(shardID uint, lastSeq string) (*connection.Records, er
 	}
 
 	// set up the shard iterator for our particular shardID
-	iter, err := a.service.GetShardIterator(params)
+	iter, err := a.service.GetShardIteratorWithContext(ctx, params)
 	if err != nil {
 		return nil, err
 	}
 
-	records, err := a.service.GetRecords(&kinesis.GetRecordsInput{
+	records, err := a.service.GetRecordsWithContext(ctx, &kinesis.GetRecordsInput{
 		ShardIterator: iter.ShardIterator,
 	})
 	if err != nil {


### PR DESCRIPTION
During Kafka implementation, I noticed that the previous mechanism `case <-time.After(1 * time.Second):` doesn't prevent from blocking Fetch function running infinitely. That's why I introduced context object with a timeout that prevents from blocking worker goroutine. 